### PR TITLE
Link vehicle registrations to supplier Firestore document ID

### DIFF
--- a/web-app/src/components/SupplierDashboard.jsx
+++ b/web-app/src/components/SupplierDashboard.jsx
@@ -23,12 +23,19 @@ const SupplierDashboard = () => {
 
           const supplierId = supplierSnapshot.docs[0].id;
 
-          // Fetch all vehicles (not filtered by supplier_id)
-          const vehicleQuery = collection(db, "vehicles");
+          // ✅ CORRECT: Filter vehicles where userId == supplierId
+          const vehicleQuery = query(
+            collection(db, "vehicles"),
+            where("userId", "==", supplierId)
+          );
           const vehicleSnapshot = await getDocs(vehicleQuery);
           setVehicles(vehicleSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
 
-          const bookingQuery = query(collection(db, "bookings"), where("supplier_id", "==", supplierId));
+          // ✅ Optional: Update bookings query if bookings use userId
+          const bookingQuery = query(
+            collection(db, "bookings"),
+            where("userId", "==", supplierId)
+          );
           const bookingSnapshot = await getDocs(bookingQuery);
           setBookings(bookingSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
         }


### PR DESCRIPTION
Modified the vehicle registration form to identify each new vehicle entry with the corresponding supplier's Firestore  ID. Instead of using the Firebase Auth UID, the system now queries the 'suppliers' collection by email to retrieve the document ID and stores it.